### PR TITLE
Fix typo in Cauchy product definition

### DIFF
--- a/analysis1/analysis1.tex
+++ b/analysis1/analysis1.tex
@@ -239,7 +239,7 @@ Sei $(a_n)$ eine Folge mit $a_n \ne 0, \forall n \ge 1$. Sei $q = \limn \sup \sq
 \subsection{Cauchy-Produkt}
 \begin{subbox}{Definition Cauchy-Produkt}
   Das Cauchy-Produkt von zwei Reihen $\sum_{i = 0}^\infty a_i$ und $\sum_{j = 0}^\infty b_j$ ist definiert als
-  $$\sum_{n=0}^\infty \sum_{j=0}^\infty (a_{n-j} \cdot b_j) = a_0b_0 + (a_0b_1 + a_1b_0) + \ldots$$ Es konvergiert, falls beide Reihen konvergieren.
+  $$\sum_{n=0}^\infty \sum_{j=0}^n (a_{n-j} \cdot b_j) = a_0b_0 + (a_0b_1 + a_1b_0) + \ldots$$ Es konvergiert, falls beide Reihen konvergieren.
 \end{subbox}
 
 \subsection{Strategie - Konvergenz von Reihen}


### PR DESCRIPTION
See def. 2.60 in the script