### PR TITLE
Fix typo in definition of Cauchy criterium

### DIFF
--- a/analysis1/analysis1.tex
+++ b/analysis1/analysis1.tex
@@ -97,7 +97,7 @@
 
 \section{Folgen}
 \subsection{Konvergenz}
-Eine Folge $(a_n)_{n\in \mathbb{N}}$ konvergiert gegen L \\ $\iff \lim_{n \to \infty} a_n = L $ \\ $\iff \forall \epsilon > 0 \ \exists N_e \ \forall n \ge N_\epsilon : \ | a_n - L | < e$\\
+Eine Folge $(a_n)_{n\in \mathbb{N}}$ konvergiert gegen L \\ $\iff \lim_{n \to \infty} a_n = L $ \\ $\iff \forall \epsilon > 0 \ \exists N_\epsilon \ \forall n \ge N_\epsilon : \ | a_n - L | < \epsilon$\\
 
 Wir dürfen (o.B.d.A.) annehmen, dass $\epsilon$ durch eine Konstante $C \in \R$ beschränkt ist.
 Es gilt ausserdem:

--- a/analysis1/analysis1.tex
+++ b/analysis1/analysis1.tex
@@ -123,7 +123,7 @@ Wenn $a_n$ monoton fallend und nach unten beschränkt ist, dann konvergiert $a_n
 \end{mainbox}
 
 \begin{mainbox}{Cauchy-Kriterium}
-Die Folge $a_n$ ist genau dann konvergent, falls $\forall e > 0 \ \exists N \ge 1$ so dass $| a_n - a_m | < \epsilon \quad \forall n,m \ge N$.
+Die Folge $a_n$ ist genau dann konvergent, falls $\forall \epsilon > 0 \ \exists N \ge 1$ so dass $| a_n - a_m | < \epsilon \quad \forall n,m \ge N$.
 \end{mainbox}
 
 \subsubsection{Teilfolge}


### PR DESCRIPTION
Should obviously be `\epsilon` instead of `e`.