### PR TITLE
Fix typo in restriction for integration of x^a

### DIFF
--- a/analysis1/analysis1.tex
+++ b/analysis1/analysis1.tex
@@ -723,7 +723,7 @@ Das unbestimmte Integral ist die Umkehroperation der Ableitung.
   $\mathbf{F(x)}$ & $\mathbf{f(x)}$ & $\mathbf{f'(x)}$ \\
   \midrule
   $\frac{x^{-a+1}}{-a+1}$ & $\frac{1}{x^a}$ & $\frac{a}{x^{a+1}}$ \\
-  $\frac{x^{a+1}}{a+1}$ & $x^a \ (a \ne 1)$ & $a \cdot x^{a-1}$ \\
+  $\frac{x^{a+1}}{a+1}$ & $x^a \ (a \ne -1)$ & $a \cdot x^{a-1}$ \\
   $\frac{1}{k \ln(a)}a^{kx}$ & $a^{kx}$ & $ka^{kx} \ln(a)$ \\
   $\ln |x|$ & $\frac{1}{x}$ & $-\frac{1}{x^2}$ \\
   $\frac{2}{3}x^{3/2}$ & $\sqrt{x}$ & $\frac{1}{2\sqrt{x}}$\\


### PR DESCRIPTION
Fixes a typo for the integral of 1/x. Integrating x^{-1} yields ln(x) + C, in every other case the rule still applies.
